### PR TITLE
Updated reqwest to 0.9.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ with-reqwest = ["reqwest"]
 [dependencies]
 error-chain = "0.11.0"
 reqwest = { version = "0.9.2", optional = true }
+mime = "0.3.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ with-reqwest = ["reqwest"]
 
 [dependencies]
 error-chain = "0.11.0"
-reqwest = { version = "0.8.0", optional = true }
+reqwest = { version = "0.9.2", optional = true }

--- a/src/reqwest.rs
+++ b/src/reqwest.rs
@@ -68,10 +68,7 @@ impl Client {
         let mut headers = HeaderMap::with_capacity(2);
         headers.insert(ACCEPT, HeaderValue::from_str("text/event-stream").unwrap());
         if let Some(ref id) = self.last_event_id {
-            headers.insert(
-                "Last-Event-ID",
-                HeaderValue::from_bytes(id.as_bytes()).unwrap(),
-            );
+            headers.insert("Last-Event-ID", HeaderValue::from_str(id).unwrap());
         }
 
         let res = self.client.get(self.url.clone()).headers(headers).send()?;

--- a/src/reqwest.rs
+++ b/src/reqwest.rs
@@ -84,9 +84,10 @@ impl Client {
             }
 
             if let Some(content_type) = res.headers().get(CONTENT_TYPE) {
-                let mime = content_type.to_str().unwrap().to_string();
-                if mime == "text/event-stream" {
-                    return Err(ErrorKind::InvalidContentType(mime).into());
+                if content_type != "text/event-stream" {
+                    return Err(ErrorKind::InvalidContentType(
+                        content_type.to_str().unwrap().to_string(),
+                    ).into());
                 }
             } else {
                 return Err(ErrorKind::NoContentType.into());

--- a/tests/reqwest.rs
+++ b/tests/reqwest.rs
@@ -10,30 +10,34 @@ mod server;
 
 fn server() -> Server {
     let s = Server::new();
-    s.receive("\
-GET / HTTP/1.1\r\n\
-Host: 127.0.0.1:$PORT\r\n\
-User-Agent: reqwest/0.8.0\r\n\
-Accept: text/event-stream\r\n\
-Accept-Encoding: gzip\r\n\
-\r\n");
+    s.receive(
+        "\
+         GET / HTTP/1.1\r\n\
+         host: 127.0.0.1:$PORT\r\n\
+         user-agent: reqwest/0.9.4\r\n\
+         accept: text/event-stream\r\n\
+         accept-encoding: gzip\r\n\
+         \r\n",
+    );
     return s;
 }
 
 #[test]
 fn simple_events() {
     let s = server();
-    s.send("HTTP/1.1 200 OK\r\n\
-Content-Type: text/event-stream\r\n\
-\r\n\
-id: 42\r\n\
-event: foo\r\n\
-data: bar\r\n\
-\r\n\
-event: bar\n\
-: comment\n\
-data: baz\n\
-\n");
+    s.send(
+        "HTTP/1.1 200 OK\r\n\
+         Content-Type: text/event-stream\r\n\
+         \r\n\
+         id: 42\r\n\
+         event: foo\r\n\
+         data: bar\r\n\
+         \r\n\
+         event: bar\n\
+         : comment\n\
+         data: baz\n\
+         \n",
+    );
 
     println!("url: {}", s.url("/"));
     let mut client = Client::new(Url::parse(&s.url("/")).unwrap());
@@ -52,12 +56,14 @@ data: baz\n\
 #[test]
 fn retry() {
     let s = server();
-    s.send("HTTP/1.1 200 OK\r\n\
-Content-Type: text/event-stream\r\n\
-\r\n\
-retry: 42\r\n\
-data: bar\r\n\
-\r\n");
+    s.send(
+        "HTTP/1.1 200 OK\r\n\
+         Content-Type: text/event-stream\r\n\
+         \r\n\
+         retry: 42\r\n\
+         data: bar\r\n\
+         \r\n",
+    );
 
     println!("url: {}", s.url("/"));
     let mut client = Client::new(Url::parse(&s.url("/")).unwrap());
@@ -69,10 +75,12 @@ data: bar\r\n\
 #[test]
 fn missing_content_type() {
     let s = server();
-    s.send("HTTP/1.1 200 OK\r\n\
-\r\n\
-data: bar\r\n\
-\r\n");
+    s.send(
+        "HTTP/1.1 200 OK\r\n\
+         \r\n\
+         data: bar\r\n\
+         \r\n",
+    );
 
     let mut client = Client::new(Url::parse(&s.url("/")).unwrap());
     match client.next().unwrap() {
@@ -84,11 +92,13 @@ data: bar\r\n\
 #[test]
 fn invalid_content_type() {
     let s = server();
-    s.send("HTTP/1.1 200 OK\r\n\
-Content-Type: text/plain\r\n\
-\r\n\
-data: bar\r\n\
-\r\n");
+    s.send(
+        "HTTP/1.1 200 OK\r\n\
+         Content-Type: text/plain\r\n\
+         \r\n\
+         data: bar\r\n\
+         \r\n",
+    );
 
     let mut client = Client::new(Url::parse(&s.url("/")).unwrap());
     match client.next().unwrap() {
@@ -100,13 +110,18 @@ data: bar\r\n\
 #[test]
 fn content_type_with_mime_parameter() {
     let s = server();
-    s.send("HTTP/1.1 200 OK\r\n\
-Content-Type: text/event-stream;charset=utf8\r\n\
-\r\n\
-data: bar\r\n\
-\r\n");
+    s.send(
+        "HTTP/1.1 200 OK\r\n\
+         Content-Type: text/event-stream;charset=utf8\r\n\
+         \r\n\
+         data: bar\r\n\
+         \r\n",
+    );
 
     let mut client = Client::new(Url::parse(&s.url("/")).unwrap());
-    let event = client.next().unwrap().expect("MIME parameter should be ignored");
+    let event = client
+        .next()
+        .unwrap()
+        .expect("MIME parameter should be ignored");
     assert_eq!(event.data, "bar\n");
 }

--- a/tests/server/mod.rs
+++ b/tests/server/mod.rs
@@ -1,17 +1,19 @@
 #![allow(dead_code)]
 
 use std::collections::HashSet;
-use std::net::{TcpListener, SocketAddr, TcpStream};
 use std::io::prelude::*;
-use std::thread;
-use std::sync::mpsc::{Sender, Receiver, channel};
 use std::io::BufReader;
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::thread;
 
 macro_rules! t {
-    ($e:expr) => (match $e {
-        Ok(e) => e,
-        Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
-    })
+    ($e:expr) => {
+        match $e {
+            Ok(e) => e,
+            Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
+        }
+    };
 }
 
 pub struct Server {
@@ -37,7 +39,7 @@ fn run(listener: &TcpListener, rx: &Receiver<Message>) {
                     expected = &expected[i + 1..];
                     expected_headers.insert(line);
                     if line == "\r\n" {
-                        break
+                        break;
                     }
                 }
 
@@ -51,25 +53,27 @@ fn run(listener: &TcpListener, rx: &Receiver<Message>) {
                     }
                     // various versions of libcurl do different things here
                     if actual == "Proxy-Connection: Keep-Alive\r\n" {
-                        continue
+                        continue;
                     }
                     if expected_headers.remove(&actual[..]) {
-                        continue
+                        continue;
                     }
 
                     let mut found = None;
                     for header in expected_headers.iter() {
                         if lines_match(header, &actual) {
                             found = Some(header.clone());
-                            break
+                            break;
                         }
                     }
                     if let Some(found) = found {
                         expected_headers.remove(&found);
-                        continue
+                        continue;
                     }
-                    panic!("unexpected header: {:?} (remaining headers {:?})",
-                           actual, expected_headers);
+                    panic!(
+                        "unexpected header: {:?} (remaining headers {:?})",
+                        actual, expected_headers
+                    );
                 }
                 for header in expected_headers {
                     panic!("expected header but not found: {:?}", header);
@@ -84,7 +88,7 @@ fn run(listener: &TcpListener, rx: &Receiver<Message>) {
                     line.truncate(0);
                     t!(socket.read_line(&mut line));
                     if line.len() == 0 {
-                        break
+                        break;
                     }
                     if expected.len() == 0 {
                         panic!("unexpected line: {:?}", line);
@@ -93,11 +97,14 @@ fn run(listener: &TcpListener, rx: &Receiver<Message>) {
                     let expected_line = &expected[..i + 1];
                     expected = &expected[i + 1..];
                     if lines_match(expected_line, &line) {
-                        continue
+                        continue;
                     }
-                    panic!("lines didn't match:\n\
-                            expected: {:?}\n\
-                            actual:   {:?}\n", expected_line, line)
+                    panic!(
+                        "lines didn't match:\n\
+                         expected: {:?}\n\
+                         actual:   {:?}\n",
+                        expected_line, line
+                    )
                 }
                 if expected.len() != 0 {
                     println!("didn't get expected data: {:?}", expected);
@@ -105,7 +112,7 @@ fn run(listener: &TcpListener, rx: &Receiver<Message>) {
             }
             Message::Write(ref to_write) => {
                 t!(socket.get_mut().write_all(to_write.as_bytes()));
-                return
+                return;
             }
         }
     }
@@ -120,13 +127,11 @@ fn lines_match(expected: &str, mut actual: &str) -> bool {
         match actual.find(part) {
             Some(j) => {
                 if i == 0 && j != 0 {
-                    return false
+                    return false;
                 }
                 actual = &actual[j + part.len()..];
             }
-            None => {
-                return false
-            }
+            None => return false,
         }
     }
     actual.is_empty() || expected.ends_with("[..]")


### PR DESCRIPTION
Uses the latest `request` version. 

WIP: tests do not currently pass on the PR branch. I have the same issues on mainline (logs below).

_Later edit: it seems that tests were written during request `0.8.0` and had hard-coded headers for this version. When request `0.8.8` became available the headers contained `0.8.8` and no longer matched the expected (old) ones. This is why tests on mainline looked broken._

```
     Running target\debug\deps\eventsource-6ad95a71519f8381.exe

running 2 tests
test event::tests::multiline_event_display ... ok
test event::tests::basic_event_display ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target\debug\deps\reqwest-e25096ba6f92364a.exe

running 5 tests
thread 'thread 'thread '<unnamed><unnamed><unnamed>' panicked at '' panicked at '' panicked at 'unexpected header: "User-Agent: reqwest/0.8.8\r\n" (remaining headers {"\r\n", "Accept: text/event-stream\r\n", "Accept-Encoding: gzip\r\n", "User-Agent: reqwest/0.8.0\r\n"})unexpected header: "User-Agent: reqwest/0.8.8\r\n" (remaining headers {"Accept: text/event-stream\r\n", "User-Agent: reqwest/0.8.0\r\n", "\r\n", "Accept-Encoding: gzip\r\n"})', unexpected header: "User-Agent: reqwest/0.8.8\r\n" (remaining headers {"Accept-Encoding: gzip\r\n", "\r\n", "Accept: text/event-stream\r\n", "User-Agent: reqwest/0.8.0\r\n"})', ', tests\server\mod.rstests\server\mod.rs:thread '71tests\server\mod.rs::<unnamed>7171:thread '21::21' panicked at '21
unexpected header: "User-Agent: reqwest/0.8.8\r\n" (remaining headers {"Accept-Encoding: gzip\r\n", "Accept: text/event-stream\r\n", "\r\n", "User-Agent: reqwest/0.8.0\r\n"})<unnamed>' panicked at 'unexpected header: "User-Agent: reqwest/0.8.8\r\n" (remaining headers {"Accept: text/event-stream\r\n", "Accept-Encoding: gzip\r\n", "User-Agent: reqwest/0.8.0\r\n", "\r\n"})',
tests\server\mod.rs:note: Run with `RUST_BACKTRACE=1` for a backtrace.

', tests\server\mod.rs:7171:21
:21
test missing_content_type ... FAILED
test retry ... FAILED
test invalid_content_type ... FAILED
test content_type_with_mime_parameter ... FAILED
test simple_events ... FAILED

failures:

---- missing_content_type stdout ----
thread 'missing_content_type' panicked at 'NoContentType error expected', tests\reqwest.rs:80:14
child server thread also failed: Any

---- retry stdout ----
url: http://127.0.0.1:51538/
thread 'retry' panicked at 'called `Result::unwrap()` on an `Err` value: Error(Reqwest(Error { kind: Http(Incomplete), url: Some("http://127.0.0.1:51538/") }), State { next_error: None, backtrace: None })', libcore\result.rs:1009:5
child server thread also failed: Any

---- invalid_content_type stdout ----
thread 'invalid_content_type' panicked at 'InvalidContentType error expected', tests\reqwest.rs:96:14
child server thread also failed: Any

---- content_type_with_mime_parameter stdout ----
thread 'content_type_with_mime_parameter' panicked at 'MIME parameter should be ignored: Error(Reqwest(Error { kind: Http(Incomplete), url: Some("http://127.0.0.1:51540/") }), State { next_error: None, backtrace: None })', libcore\result.rs:1009:5
child server thread also failed: Any

---- simple_events stdout ----
url: http://127.0.0.1:51539/
thread 'simple_events' panicked at 'called `Result::unwrap()` on an `Err` value: Error(Reqwest(Error { kind: Http(Incomplete), url: Some("http://127.0.0.1:51539/") }), State { next_error: None, backtrace: None })', libcore\result.rs:1009:5
child server thread also failed: Any


failures:
    content_type_with_mime_parameter
    invalid_content_type
    missing_content_type
    retry
    simple_events

test result: FAILED. 0 passed; 5 failed; 0 ignored; 0 measured; 0 filtered out

error: test failed, to rerun pass '--test reqwest'
```