### PR TITLE
Fix readme code

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ use eventsource::reqwest::Client;
 use reqwest::Url;
                                                                                               
 fn main() {
-    let client = Client::new(Url::parse("http://example.com").unwrap()).unwrap();
+    let client = Client::new(Url::parse("http://example.com").unwrap());
     for event in client {
         println!("{}", event.unwrap());
     }


### PR DESCRIPTION
If I try to compile the code in the readme it complains about this `unwrap()`. Without it it compiles.