### PR TITLE
Switch to thiserror (BREAKING)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eventsource"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Lukas Werling <lukas.werling@gmail.com>"]
 edition = "2018"
 
@@ -13,9 +13,9 @@ keywords = ["http"]
 default = ["with-reqwest"]
 
 # Enable the reqwest-based client.
-with-reqwest = ["reqwest"]
+with-reqwest = ["reqwest", "thiserror"]
 
 [dependencies]
-error-chain = "0.12.2"
+thiserror = { version = "1.0.21", optional = true }
 reqwest = { version = "0.10.4", features = ["blocking"], optional = true }
 mime = "0.3.7"

--- a/tests/reqwest.rs
+++ b/tests/reqwest.rs
@@ -1,4 +1,4 @@
-use eventsource::reqwest::{Client, Error, ErrorKind};
+use eventsource::reqwest::{Client, Error};
 use reqwest::Url;
 use std::time::Duration;
 
@@ -79,7 +79,7 @@ fn missing_content_type() {
 
     let mut client = Client::new(Url::parse(&s.url("/")).unwrap());
     match client.next().unwrap() {
-        Err(Error(ErrorKind::NoContentType, _)) => assert!(true),
+        Err(Error::NoContentType) => assert!(true),
         _ => assert!(false, "NoContentType error expected"),
     }
 }
@@ -97,7 +97,7 @@ fn invalid_content_type() {
 
     let mut client = Client::new(Url::parse(&s.url("/")).unwrap());
     match client.next().unwrap() {
-        Err(Error(ErrorKind::InvalidContentType(_), _)) => assert!(true),
+        Err(Error::InvalidContentType(_)) => assert!(true),
         _ => assert!(false, "InvalidContentType error expected"),
     }
 }


### PR DESCRIPTION
error-chain is declining in popularity. It also, more importantly, does not implement Sync on its errors. This causes issues with popular parts of the ecosystem such as anyhow. thiserror is a minimal alternative to error-chain that fulfills this crate's needs, and implements Sync. However, error-chain is exposed in the public API, making this a breaking change. I bumped the crate version to 0.6.0.