### PR TITLE
Bump reqwest version for compatibility with tokio 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.0 - 2021-03-13
+
+### Changed
+ - Update reqwest to 0.11.x. This implies tokio ^1.0.
+
 ## 0.5.0 - 2020-04-21
 ### Added
  - `Client::new_with_client()` allows passing a custom reqwest client. ([#8](https://github.com/lluchs/eventsource/pull/8))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eventsource"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Lukas Werling <lukas.werling@gmail.com>"]
 edition = "2018"
 
@@ -17,5 +17,5 @@ with-reqwest = ["reqwest"]
 
 [dependencies]
 error-chain = "0.12.2"
-reqwest = { version = "0.10.4", features = ["blocking"], optional = true }
+reqwest = { version = "0.11.0", features = ["blocking"], optional = true }
 mime = "0.3.7"


### PR DESCRIPTION
As the title suggests, it would be great to be able to use `eventsource` within the context of a `tokio` 1.x world, so bumping the `reqwest` dependency to a version that uses `tokio` 1.x is the whole story here.

Thanks!